### PR TITLE
Remove pdb breakpoint

### DIFF
--- a/geoprocessing/customRequest.py
+++ b/geoprocessing/customRequest.py
@@ -407,9 +407,6 @@ if lol:
                 packageProduct(crZip, quadScenePairList[0] + "_" + quadScenePairList[1] +'_*.tif*')
 
         # add layer files
-######################################################################################################################################
-	pdb.set_trace()
-######################################################################################################################################
         for base, dirs, files in os.walk(os.path.join(LSF.productStorage, 'layer_files')):
             for fileName in files:
                 crZip.write(os.path.join(base, fileName))


### PR DESCRIPTION
Deleted 3 lines that were used to debug the addition of layer files to the CR zip. The breakpoint should not have been left in the production code since running it outside of Debug mode generates an unhandled exception (BdbQuit).
