### PR TITLE
customRequest nows looks for project_storage before downloading tar

### DIFF
--- a/geoprocessing/customRequest.py
+++ b/geoprocessing/customRequest.py
@@ -146,13 +146,17 @@ def extractedTar(quadsceneID):
 #
 """
 def quadScene(quadsceneID):
-    # ideally, if there are clipped TIFFs, the previous work artifacts could safely no longer be there
-    # but for now, we still need the mtlData from the sceneID_MTLFmask.TIF in /lsfdata/eros_data/extractedTars
-    # make sure that /lsfdata/extractedTars/sceneID contains the level 1 product band files
-    extractedTar(quadsceneID)
+    # this function is a little more complicated because it tries to take one of two possible shortcuts.
+    # if there are clipped TIFFs, the previous work artifacts can safely no longer be there.
+    # if the clipped TIFFs aren't there, look for unclipped TIFFs in tiffsStorage first.
+    # if the unclipped TIFFs aren't there, the extractedTar "target" function will cause the tar to be downloaded
+
     sceneID=quadsceneID[:-2]
+    pdb.set_trace()
     if not(re.search(quadsceneID, ' '.join(glob.glob(os.path.join(LSF.projectStorage, '*'))))):
-        # if the band files for quadsceneID in are not in projectStorage, get them from tiffsStorage, if necessary, and clip them
+        # if the band files for quadsceneID in are not in projectStorage, get them from tiffsStorage, if possible, and clip them
+        if not (re.search(sceneID, ' '.join(glob.glob(os.path.join(LSF.tiffsStorage, '*'))))):
+            extractedTar(quadsceneID)
         quadPaths = rasterAnalysis_GDAL.cropToQuad(os.path.join(LSF.tiffsStorage, sceneID), LSF.projectStorage, LSF.quadsFolder)
         landsatFactTools_GDAL.writeQuadToDB(quadPaths)
         # get cloud cover percentage for each quad


### PR DESCRIPTION
Change customRequests to look for intermediate work products in extractedTars and project_storage before downloading missing tars from glovis
