### PR TITLE
Remove tars from eros_data after processing

### DIFF
--- a/geoprocessing/landsatFACT_LCV.py
+++ b/geoprocessing/landsatFACT_LCV.py
@@ -37,8 +37,8 @@ import LSFGeoTIFF
 #runList = ast.literal_eval( sys.argv[1] )
 runList=[]
 extractedList = []
+exceptList = []
 infile = sys.argv[1]
-runlist=[]
 with open(infile) as inf:
     for line in inf:
         m=re.search('L.*?\.tar\.gz', line)
@@ -219,9 +219,16 @@ for tar in runList:
         print "Error in LCV"
         print str(e)
         landsatFactTools_GDAL.sendEmail(tar + ': ' + str(e))
+        exceptList.append(tar)
         continue
 
 print '\nLandsatFACT Complete'
 print 'Processed ', runList, extractedList
+print 'Excepting ', exceptList
+runList.extend(extractedList)
+# Clean up tars that have successfully been processed
+for t in runList:
+    if t not in exceptList:
+        os.remove(t)
 sys.exit()
 


### PR DESCRIPTION
LCV keeps track of tars that have been successfully processed including ones that have been downloaded on demand by calls to download_landsat_data_by_sceneid.php from extractProductForCompare in landsatFactTools_GDAL.py. It also keeps track of which tars have not been successfully processed due to errors. At the end of LCV processing, it removes tars that have been processed to at least project_data.
