### PR TITLE
fixes issue #158 by insuring downloaded tars are in date order

### DIFF
--- a/geoprocessing/landsatFACT_LCV.py
+++ b/geoprocessing/landsatFACT_LCV.py
@@ -44,6 +44,7 @@ with open(infile) as inf:
         m=re.search('L.*?\.tar\.gz', line)
         if m:
             runList.append(m.group())
+runList.sort(key=lambda tar: tar[9:16])
 os.chdir(tarStorage)
 
 for tar in runList:


### PR DESCRIPTION
Changes to landsatFACT_LCV.py to order downloaded tars before processing
