### PR TITLE
fixes issue #153

### DIFF
--- a/geoprocessing/landsatFACT_LCV.py
+++ b/geoprocessing/landsatFACT_LCV.py
@@ -20,7 +20,7 @@ def main():
 if __name__ == '__main__':
     main()
 
-import os, sys, re
+import os, sys, re, traceback
 import landsatFactTools_GDAL
 import rasterAnalysis_GDAL
 import numpy as np
@@ -219,7 +219,7 @@ for tar in runList:
     except BaseException as e:
         print "Error in LCV"
         print str(e)
-        landsatFactTools_GDAL.sendEmail(tar + ': ' + str(e))
+        landsatFactTools_GDAL.sendEmail(tar + ': ' + "\n".join([str(e), traceback.format_exc()]))
         exceptList.append(tar)
         continue
 

--- a/geoprocessing/landsatFactTools_GDAL.py
+++ b/geoprocessing/landsatFactTools_GDAL.py
@@ -48,13 +48,15 @@ def extractProductForCompare(diff_tar,tarStorage,tiffsStorage,fmaskShellCall,qua
         os.chdir(LSF.path_projects + '/dataexchange')
         print os.getcwd()
         # download the scene data
-        subprocess.call(["php", "download_landsat_data_by_sceneid.php", diff_tar])
+        errcode=subprocess.call(["php", "download_landsat_data_by_sceneid.php", diff_tar])
+        if errcode:
+            raise RuntimeError(errcode)
         # now extract the downloaded file accordingly
         inNewSceneTar = os.path.join(tarStorage, diff_tar+".tar.gz")
         print inNewSceneTar
         err=localLib.validTar(inNewSceneTar)
         if err:
-            raise Exception(err)
+            raise RuntimeError(err)
         extractedPath = checkExisting(inNewSceneTar, tiffsStorage)
         #do the other pre-processing stuff
         os.chdir(in_dir)
@@ -76,7 +78,9 @@ def extractProductForCompare(diff_tar,tarStorage,tiffsStorage,fmaskShellCall,qua
         print os.getcwd()
     except Exception as e:
         print "Error in extractProductForCompare"
-        print str(e)
+        # make sure we've returned to the original directory before raising this exception
+        os.chdir(in_dir)
+        raise
 
 def readAndWriteQuadCC(quadPaths, extractedPath):
     quadCCDict={}
@@ -92,6 +96,7 @@ def readAndWriteQuadCC(quadPaths, extractedPath):
         pymsg = "PYTHON ERRORS:\nTraceback Info:\n" + tbinfo + "\nError Info:\n    " + \
         str(sys.exc_type)+ ": " + str(sys.exc_value) + "\n"
         #sendEmail(pymsg)
+        print pymsg
     finally:
         return quadCCDict
 

--- a/geoprocessing/rasterAnalysis_GDAL.py
+++ b/geoprocessing/rasterAnalysis_GDAL.py
@@ -407,31 +407,30 @@ def cropToQuad(inRastFolder, outRasterFolder, quadsFolder):
     return sceneQuadList
 
 def runFmask(tiffFolder,fmaskShellCall):
-	""" """
-	try:
-		return_value = True;
-		print "In runFmask checking for: "+os.path.join(tiffFolder,os.path.basename(tiffFolder) + "_MTLFmask.TIF")
-		print "fmaskShellCall: "+fmaskShellCall
-		if os.path.exists(os.path.join(tiffFolder,os.path.basename(tiffFolder) + "_MTLFmask.TIF")) == False:
-			print "Running Fmask"
-			print "tiffFolder: "+tiffFolder
-			landsatFactTools_GDAL.cleanDir(tiffFolder)
-			print("working dir:" + os.getcwd() + "\n")
-			try:
-				process = subprocess.Popen([fmaskShellCall],cwd=tiffFolder,stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-				out,err = process.communicate()
-				errcode = process.returncode
-				os.rename(os.path.join(tiffFolder,os.path.basename(tiffFolder)+"_MTLFmask"), os.path.join(tiffFolder,os.path.basename(tiffFolder)+"_MTLFmask.TIF"))
-			except:
-				print "Fmask subprocess failed."+"\n"
-		else:
-			print "Mask already created for: "+tiffFolder
-		return return_value
-	except:
-		if out in vars() or out in globals():
-			print("Fmask Execution failed:"+str(out)+"/n"+str(err)+"/n"+str(errcode))
-		return_value = False;
-		return return_value
+        """ """
+        try:
+                return_value = True;
+                print "In runFmask checking for: "+os.path.join(tiffFolder,os.path.basename(tiffFolder) + "_MTLFmask.TIF")
+                print "fmaskShellCall: "+fmaskShellCall
+                if os.path.exists(os.path.join(tiffFolder,os.path.basename(tiffFolder) + "_MTLFmask.TIF")) == False:
+                        print "Running Fmask"
+                        print "tiffFolder: "+tiffFolder
+                        landsatFactTools_GDAL.cleanDir(tiffFolder)
+                        print("working dir:" + os.getcwd() + "\n")
+                        process = subprocess.Popen([fmaskShellCall],cwd=tiffFolder,stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+                        out,err = process.communicate()
+                        errcode = process.returncode
+                        if not errcode:
+                            os.rename(os.path.join(tiffFolder,os.path.basename(tiffFolder)+"_MTLFmask"), os.path.join(tiffFolder,os.path.basename(tiffFolder)+"_MTLFmask.TIF"))
+                        else:
+                            raise RuntimeError("There was an issue with FMASK on: "+tiffFolder)
+                else:
+                        print "Mask already created for: "+tiffFolder
+                return return_value
+        except:
+                if 'out' in vars() or 'out' in globals():
+                        print("Fmask Execution failed:"+str(out)+"/n"+str(err)+"/n"+str(errcode))
+                raise
 
 def cloudCover(FmaskData):
     """ """


### PR DESCRIPTION
Fmask failures can go unnoticed. Changed the exception handling in LCV to include the call stack in the email to landsatfactmsg@gmail. Changed the exception handling for the runFmask in rasterAnalysis_GDAL.py to bubble up any exceptions to LCV so that landsatfactmsg can be informed and LCV can save the offending tar for future debugging.
Also added a check of the return code from download_landsat_data_by_sceneid called by the extractProductForCompare in landsatFactTools_GDAL.py.
