### PR TITLE
LCV attempts to re-download invalid tars

### DIFF
--- a/geoprocessing/landsatFACT_LCV.py
+++ b/geoprocessing/landsatFACT_LCV.py
@@ -49,13 +49,14 @@ os.chdir(tarStorage)
 
 for tar in runList:
     try:
-                # set tar file to analyze
+        # set tar file to analyze
         if not tar[-7:] == '.tar.gz':
             print "incorrect file type"
             raise RuntimeError("Not a tarball: "+tar)
         err=localLib.validTar(tar)
         if err:
-            raise RuntimeError(err)
+            os.remove(tar)
+            landsatFactTools_GDAL.retry(1, 4, landsatFactTools_GDAL.DownloadError,landsatFactTools_GDAL.downloadScene, tar[:-7])
         # all  paths are now imported from LSF.py  DM - 5/10/2016
         # =========================================================================
         # sets full path for the tarfile to be analyzed


### PR DESCRIPTION
Added code to landsatFactTools_GDAL.py that enables retrying the download of scenes which LCV identifies as invalid tars. Usually, these tars have a file length of zero but other download errors have been seen. Refactored the extractProductForCompare function to pull out the code which calls download_landsat_data_by_sceneid.php. The new function, downloadScene, raises a user-defined exception, DownloadError, when the download results in an invalid tar. Added a new function retry function which will retry a given function up to maxAllowedAttempts when it encounters a given exceptionClassSignalingRetry. Changed the extractProductForCompare function to retry downloadScene in the event of a DownloadError. Modified landsatFACT_LCV.py to call downloadScene (with retry if necessary) in the event it tries to process an invalid tar in the eros_data directory.
