### PR TITLE
second part of fix for issue #169

### DIFF
--- a/geoprocessing/customRequest.py
+++ b/geoprocessing/customRequest.py
@@ -123,7 +123,7 @@ def extractedTar(quadsceneID):
     tar(sceneID)
     # if /lsfdata/extractedTars/sceneID doesn't contain the level 1 product band files, extract them from the tar file
     #
-    if not(re.search(sceneID, ' '.join(glob.glob(os.path.join(LSF.tiffsStorage, '*'))))):
+    if not(re.search(sceneID, ' '.join(glob.glob(os.path.join(LSF.tiffsStorage, '*', '*.TIF*'))))):
         # make sure that the existing tar is valid
         existingTar=os.path.join(LSF.tarStorage, sceneID+".tar.gz")
         err=localLib.validTar(existingTar)


### PR DESCRIPTION
Needed to make the previous fix in the extendedTar function too. If a tar is present in eros_data directory ( and the code does not go through the extractProductForCompare function) but no tiffs are present in extractedTars directory, the code needs to extract the tiffs from the tar. 
