### PR TITLE
fixes error operands could not be broadcast together

### DIFF
--- a/geoprocessing/customRequest.py
+++ b/geoprocessing/customRequest.py
@@ -138,6 +138,9 @@ def extractedTar(quadsceneID):
             dnMinDict = rasterAnalysis_GDAL.getDNmin(extractedPath)
             # fix bug introduced by me in commit de5df07c4ca3ff71ae4d7da27b6018fe1bc2df04
             landsatFactTools_GDAL.writeDNminToDB(dnMinDict,extractedPath)
+        # awkward but make sure mtl file has been read and put into the DB if necessary
+        rasterAnalysis_GDAL.mtlData(sceneID,os.path.join(LSF.tiffsStorage,sceneID,sceneID+'_MTL.txt'))
+
 
 """
 # Function that guarantees that the quadsceneID directory (e.g., 'LE70170362013133EDC00UL') is present in projectStorage, /lsfdata/project_data,
@@ -388,6 +391,7 @@ def compare(quadsceneID1, quadsceneID2):
 
 
 # process one change request
+
 customRequestInfo=getCustomRequestFromDB()
 lol=customRequestInfo[0]
 request_id=customRequestInfo[1]

--- a/geoprocessing/landsatFACT_LCV.py
+++ b/geoprocessing/landsatFACT_LCV.py
@@ -83,6 +83,8 @@ for tar in runList:
             if dnminExists == False:
                 dnMinDict = rasterAnalysis_GDAL.getDNmin(extractedPath)
                 landsatFactTools_GDAL.writeDNminToDB(dnMinDict,extractedPath)
+            # awkward but make sure mtl file has been read and put into the DB if necessary
+            rasterAnalysis_GDAL.mtlData(tar[:-7],os.path.join(tiffsStorage,tar[:-7],tar[:-7]+'_MTL.txt'))   
             # create quads from the input scene
             quadPaths = rasterAnalysis_GDAL.cropToQuad(extractedPath,projectStorage,quadsFolder)
             landsatFactTools_GDAL.writeQuadToDB(quadPaths)

--- a/geoprocessing/landsatFactTools_GDAL.py
+++ b/geoprocessing/landsatFactTools_GDAL.py
@@ -139,6 +139,8 @@ def extractProductForCompare(diff_tar,tarStorage,tiffsStorage,fmaskShellCall,qua
             dnMinDict = rasterAnalysis_GDAL.getDNmin(extractedPath)
             # fix bug introduced by me in commit de5df07c4ca3ff71ae4d7da27b6018fe1bc2df04
             writeDNminToDB(dnMinDict,extractedPath)
+        # awkward but make sure mtl file has been read and put into the DB if necessary
+        rasterAnalysis_GDAL.mtlData(diff_tar,os.path.join(tiffsStorage,diff_tar,diff_tar+'_MTL.txt'))
         # create quads from the input scene
         quadPaths = rasterAnalysis_GDAL.cropToQuad(extractedPath,outRasterFolder,quadsFolder)
         writeQuadToDB(quadPaths)


### PR DESCRIPTION
Fixes the error from numpy 'error operands could not be broadcast together' arising from the attempt to combine diffferent sized (rows and columns) TIFFs when generating our products. The different sized TIFFs were an artifact of clipping and reprojecting incorrectly.